### PR TITLE
`HU-Auth-01 | T-A1.6` Test: configura la base para pruebas…

### DIFF
--- a/bancalite-backend/src/Bancalite.Persitence/Bancalite.Persitence.csproj
+++ b/bancalite-backend/src/Bancalite.Persitence/Bancalite.Persitence.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Bogus" Version="35.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0-preview.2.24128.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.2.24128.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-preview.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.2.24128.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/bancalite-backend/src/Bancalite.Persitence/DependencyInjection.cs
+++ b/bancalite-backend/src/Bancalite.Persitence/DependencyInjection.cs
@@ -34,7 +34,14 @@ namespace Bancalite.Persitence
                     conn = $"Host={host};Port={port};Database={db};Username={user};Password={pass};Pooling=true";
                 }
 
-                options.UseNpgsql(conn);
+                if (string.Equals(conn, "UseInMemoryDb", StringComparison.OrdinalIgnoreCase))
+                {
+                    options.UseInMemoryDatabase("Bancalite_InMemory");
+                }
+                else
+                {
+                    options.UseNpgsql(conn);
+                }
 
                 // Diagnóstico útil en desarrollo
                 var envName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
@@ -51,3 +58,4 @@ namespace Bancalite.Persitence
         }
     }
 }
+

--- a/bancalite-backend/src/Bancalite.WebApi/Bancalite.WebApi.csproj
+++ b/bancalite-backend/src/Bancalite.WebApi/Bancalite.WebApi.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-preview.2.24128.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.2.24128.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/bancalite-backend/src/Bancalite.WebApi/Extensions/IdentityServiceExtensions.cs
+++ b/bancalite-backend/src/Bancalite.WebApi/Extensions/IdentityServiceExtensions.cs
@@ -21,6 +21,15 @@ namespace Bancalite.WebApi.Extensions
             var opts = section.Get<JwtOptions>() ?? new JwtOptions();
             var key = opts.Key ?? string.Empty;
 
+            // Fallback seguro para evitar key vacía (tests/entornos sin configuración completa)
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = "dev-fallback-key-0123456789abcdef0123456789abcdef"; // 64 chars
+                opts.Issuer ??= "Bancalite.WebApi";
+                opts.Audience ??= "Bancalite.Client";
+            }
+
+            // Configuración de autenticación JWT
             services
                 .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(o =>
@@ -67,3 +76,5 @@ namespace Bancalite.WebApi.Extensions
         }
     }
 }
+
+

--- a/bancalite-backend/src/Bancalite.WebApi/Program.cs
+++ b/bancalite-backend/src/Bancalite.WebApi/Program.cs
@@ -101,3 +101,6 @@ app.MapGet("/status", () => Results.Json(new
 app.MapControllers();
 
 app.Run();
+
+// Clase Program parcial para pruebas de integración
+public partial class Program { }

--- a/bancalite-backend/src/Bancalite.WebApi/appsettings.Development.json
+++ b/bancalite-backend/src/Bancalite.WebApi/appsettings.Development.json
@@ -1,0 +1,32 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Port=5432;Database=bancalite;Username=admin;Password=Admin1234;Pooling=true"
+  },
+  "JWT": {
+    "Key": "f9a2b1e8d7c6b5a4d3c2b1a0f9e8d7c6b5a4d3c2b1a0f9e8d7c6b5a4d3c2b1a0",
+    "Issuer": "Bancalite.WebApi",
+    "Audience": "Bancalite.Client",
+    "ExpiresMinutes": 60
+  },
+  "Smtp": {
+    "Host": "smtp.ethereal.email",
+    "Port": 587,
+    "EnableSsl": true,
+    "Username": "orpha.hammes@ethereal.email",
+    "Password": "3wA4QaTE2PHG7JK26x",
+    "SenderEmail": "orpha.hammes@ethereal.email",
+    "SenderName": "Bancalite"
+  },
+  "ADMIN_USERNAME": "admin",
+  "ADMIN_EMAIL": "alexis11dimen@gmail.com",
+  "ADMIN_PASSWORD": "alexis11dimen@gmail.com",
+  "Auth": {
+    "RefreshDays": 7
+  }
+}

--- a/bancalite-backend/tests/Tests.Unit/Auth/AuthFlowTests.cs
+++ b/bancalite-backend/tests/Tests.Unit/Auth/AuthFlowTests.cs
@@ -1,0 +1,71 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace Tests.Unit.Auth;
+
+// Tests del flujo completo de autenticación: login, me, logout, refresh
+public class AuthFlowTests : IClassFixture<CustomWebApiFactory>
+{
+    private readonly CustomWebApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public AuthFlowTests(CustomWebApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact(DisplayName = "Login -> Me: retorna perfil con token válido")]
+    public async Task Login_Then_Me_Should_Return_Profile()
+    {
+        var login = new { email = "admin@test.local", password = "Admin123$" };
+        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", login);
+        loginResp.EnsureSuccessStatusCode();
+        var profile = await loginResp.Content.ReadFromJsonAsync<ProfileDto>();
+        profile.Should().NotBeNull();
+        profile!.token.Should().NotBeNullOrEmpty();
+
+        _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", profile.token);
+        var meResp = await _client.GetAsync("/api/auth/me");
+        meResp.IsSuccessStatusCode.Should().BeTrue();
+    }
+
+    // Logout invalida access token inmediatamente
+    [Fact(DisplayName = "Logout revoca access token inmediatamente (401 en /me)")]
+    public async Task Logout_Should_Invalidate_AccessToken()
+    {
+        var login = new { email = "admin@test.local", password = "Admin123$" };
+        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", login);
+        loginResp.EnsureSuccessStatusCode();
+        var profile = await loginResp.Content.ReadFromJsonAsync<ProfileDto>();
+        _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", profile!.token);
+
+        var meOk = await _client.GetAsync("/api/auth/me");
+        meOk.IsSuccessStatusCode.Should().BeTrue();
+
+        var logoutResp = await _client.PostAsJsonAsync("/api/auth/logout", new { refreshToken = profile.refreshToken });
+        logoutResp.EnsureSuccessStatusCode();
+
+        var meUnauthorized = await _client.GetAsync("/api/auth/me");
+        meUnauthorized.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
+    }
+
+    // Refresh rota refresh token y entrega nuevo access token
+    [Fact(DisplayName = "Refresh rota refresh token y entrega nuevo access token")]
+    public async Task Refresh_Should_Rotate_And_Return_New_Tokens()
+    {
+        var login = new { email = "admin@test.local", password = "Admin123$" };
+        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", login);
+        loginResp.EnsureSuccessStatusCode();
+        var profile = await loginResp.Content.ReadFromJsonAsync<ProfileDto>();
+
+        var refreshResp = await _client.PostAsJsonAsync("/api/auth/refresh", new { refreshToken = profile!.refreshToken });
+        refreshResp.EnsureSuccessStatusCode();
+        var profile2 = await refreshResp.Content.ReadFromJsonAsync<ProfileDto>();
+
+        profile2!.token.Should().NotBeNullOrEmpty().And.NotBe(profile.token);
+        profile2.refreshToken.Should().NotBe(profile.refreshToken);
+    }
+
+    private record ProfileDto(string? nombreCompleto, string? email, string? token, string? refreshToken);
+}

--- a/bancalite-backend/tests/Tests.Unit/Auth/CustomWebApiFactory.cs
+++ b/bancalite-backend/tests/Tests.Unit/Auth/CustomWebApiFactory.cs
@@ -1,0 +1,121 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Bancalite.Application.Interface;
+using Bancalite.Persitence;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Identity;
+using Bancalite.Persitence.Model;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Tests.Unit.Auth;
+
+// WebApplicationFactory personalizado para pruebas de integración
+public class CustomWebApiFactory : WebApplicationFactory<Program>
+{
+    // Configuración del host para pruebas
+    // Usa InMemoryDb, parámetros fijos para JWT y un IEmailSender de prueba
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Production");
+        builder.ConfigureAppConfiguration((ctx, cfg) =>
+        {
+            var dict = new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Default"] = "UseInMemoryDb",
+                ["JWT:Key"] = "unit-test-key-0123456789abcdef0123456789abcdef",
+                ["JWT:Issuer"] = "Bancalite.WebApi",
+                ["JWT:Audience"] = "Bancalite.Client",
+                ["JWT:ExpiresMinutes"] = "30",
+                ["Auth:RefreshDays"] = "7",
+                ["ADMIN_USERNAME"] = "admin",
+                ["ADMIN_EMAIL"] = "admin@test.local",
+                ["ADMIN_PASSWORD"] = "Admin123$",
+                ["Smtp:Host"] = "smtp.test",
+                ["Smtp:Port"] = "25",
+                ["Smtp:EnableSsl"] = "false",
+                ["Smtp:Username"] = "user",
+                ["Smtp:Password"] = "pass",
+                ["Smtp:SenderEmail"] = "no-reply@test.local"
+            };
+            cfg.AddInMemoryCollection(dict!);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<BancaliteContext>));
+            if (descriptor != null) services.Remove(descriptor);
+            services.AddDbContext<BancaliteContext>(o => o.UseInMemoryDatabase("AuthTestsDb"));
+
+            services.AddSingleton<IEmailSender, TestEmailSender>();
+            services.AddHostedService<TestSeedHostedService>();
+
+            // Forzar par�metros de JwtBearer en pruebas (clave y validaci�n)
+            services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, o =>
+            {
+                var key = Encoding.UTF8.GetBytes("unit-test-key-0123456789abcdef0123456789abcdef");
+                o.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuer = "Bancalite.WebApi",
+                    ValidateAudience = true,
+                    ValidAudience = "Bancalite.Client",
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(key),
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.Zero
+                };
+            });
+        });
+    }
+}
+
+// IEmailSender de prueba que almacena el último mensaje enviado en memoria
+public class TestEmailSender : IEmailSender
+{
+    public record Message(string To, string Subject, string Html, string? Text);
+    public Message? Last { get; private set; }
+
+    public Task SendAsync(string to, string subject, string htmlBody, string? textBody = null, CancellationToken ct = default)
+    {
+        Last = new Message(to, subject, htmlBody, textBody);
+        return Task.CompletedTask;
+    }
+}
+
+// HostedService para inicializar datos de prueba (roles y usuario admin)
+public class TestSeedHostedService : IHostedService
+{
+    private readonly IServiceProvider _services;
+    public TestSeedHostedService(IServiceProvider services) { _services = services; }
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BancaliteContext>();
+
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
+        foreach (var r in new[] { "Admin", "User" })
+            if (!await roleManager.RoleExistsAsync(r)) await roleManager.CreateAsync(new IdentityRole<Guid>(r));
+
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+        var admin = await userManager.FindByEmailAsync("admin@test.local");
+        if (admin == null)
+        {
+            admin = new AppUser { Id = Guid.NewGuid(), Email = "admin@test.local", UserName = "admin", EmailConfirmed = true, DisplayName = "Admin System" };
+            await userManager.CreateAsync(admin, "Admin123$");
+            await userManager.AddToRoleAsync(admin, "Admin");
+        }
+    }
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+
+
+
+

--- a/bancalite-backend/tests/Tests.Unit/Tests.Unit.csproj
+++ b/bancalite-backend/tests/Tests.Unit/Tests.Unit.csproj
@@ -12,10 +12,17 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bancalite.WebApi\Bancalite.WebApi.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# `HU-Auth-01 | T-A1.6` Test(testing): configura la base para pruebas de integración

* Se habilita el uso de WebApplicationFactory en el proyecto de pruebas haciendo la clase Program parcial.
* Se configura el DbContext para usar una base de datos en memoria cuando la cadena de conexión es "UseInMemoryDb".
* Se añaden valores de configuración JWT de respaldo para evitar fallos de arranque en entornos de prueba.
* Se agregan los paquetes NuGet necesarios (Mvc.Testing, EFCore.InMemory, FluentAssertions) al proyecto de pruebas.
* Referencias: [US_ID=HU-Auth-01] [Task_ID=T-A1.6]

**Tarea:** #59
