### PR TITLE
`HU-Rep-01 | T-E1.1` Feat(reportes): añade endpoint para reporte de estado de cuenta en JSON y PDF

### DIFF
--- a/bancalite-backend/src/Bancalite.Application/Interface/IPdfRenderer.cs
+++ b/bancalite-backend/src/Bancalite.Application/Interface/IPdfRenderer.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bancalite.Application.Interface
+{
+    /// <summary>
+    /// Servicio para renderizar PDF desde un DTO de reporte.
+    /// </summary>
+    public interface IPdfRenderer
+    {
+        /// <summary>
+        /// Renderiza un reporte de estado de cuenta en PDF.
+        /// </summary>
+        Task<byte[]> RenderEstadoCuentaAsync(object reporteDto, CancellationToken ct = default);
+    }
+}
+

--- a/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaDto.cs
+++ b/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaDto.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bancalite.Application.Reportes.EstadoCuenta
+{
+    /// <summary>
+    /// DTO del reporte de estado de cuenta (compartido entre JSON y PDF).
+    /// </summary>
+    public class EstadoCuentaDto
+    {
+        public Guid? ClienteId { get; set; }
+        public string? ClienteNombre { get; set; }
+        public string? NumeroCuenta { get; set; }
+        public DateTime Desde { get; set; }
+        public DateTime Hasta { get; set; }
+
+        public decimal TotalCreditos { get; set; }
+        public decimal TotalDebitos { get; set; }
+        public decimal SaldoInicial { get; set; }
+        public decimal SaldoFinal { get; set; }
+
+        public List<EstadoCuentaItemDto> Movimientos { get; set; } = new();
+    }
+}

--- a/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaItemDto.cs
+++ b/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaItemDto.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Bancalite.Application.Reportes.EstadoCuenta
+{
+    /// <summary>
+    /// Item de detalle de movimiento para el reporte de estado de cuenta.
+    /// </summary>
+    public class EstadoCuentaItemDto
+    {
+        public DateTime Fecha { get; set; }
+        public string NumeroCuenta { get; set; } = string.Empty;
+        public string TipoCodigo { get; set; } = string.Empty;
+        public decimal Monto { get; set; }
+        public decimal SaldoPrevio { get; set; }
+        public decimal SaldoPosterior { get; set; }
+        public string? Descripcion { get; set; }
+    }
+}
+

--- a/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaQuery.cs
+++ b/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaQuery.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bancalite.Application.Core;
+using Bancalite.Application.Interface;
+using Bancalite.Persitence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bancalite.Application.Reportes.EstadoCuenta
+{
+    /// <summary>
+    /// Query para obtener el reporte de estado de cuenta (JSON/PDF comparten DTO).
+    /// </summary>
+    public class EstadoCuentaQuery
+    {
+        public record EstadoCuentaQueryRequest(EstadoCuentaRequest Request) : IRequest<Result<EstadoCuentaDto>>;
+
+        internal class Handler : IRequestHandler<EstadoCuentaQueryRequest, Result<EstadoCuentaDto>>
+        {
+            private readonly BancaliteContext _context;
+            private readonly IUserAccessor _userAccessor;
+
+            public Handler(BancaliteContext context, IUserAccessor userAccessor)
+            {
+                _context = context;
+                _userAccessor = userAccessor;
+            }
+
+            public async Task<Result<EstadoCuentaDto>> Handle(EstadoCuentaQueryRequest message, CancellationToken ct)
+            {
+                var req = message.Request;
+                if (req.ClienteId == null && string.IsNullOrWhiteSpace(req.NumeroCuenta))
+                    return Result<EstadoCuentaDto>.Failure("BadRequest: Debe indicar clienteId o numeroCuenta");
+                if (req.Desde > req.Hasta)
+                    return Result<EstadoCuentaDto>.Failure("BadRequest: Rango de fechas inválido");
+
+                var identidad = _userAccessor.GetUsername();
+                if (string.IsNullOrWhiteSpace(identidad)) return Result<EstadoCuentaDto>.Failure("Unauthorized");
+
+                // Resolver cuentas destino y autorización
+                List<Guid> cuentaIds = new();
+                Guid? clienteId = null;
+                string? clienteNombre = null;
+                string? numeroCuenta = null;
+
+                bool esAdmin = await (from ur in _context.UserRoles
+                                       join r in _context.Roles on ur.RoleId equals r.Id
+                                       join u in _context.Users on ur.UserId equals u.Id
+                                       where (u.Email == identidad || u.UserName == identidad || u.Id.ToString() == identidad) && r.Name == "Admin"
+                                       select ur).AnyAsync(ct);
+
+                if (!string.IsNullOrWhiteSpace(req.NumeroCuenta))
+                {
+                    var cuenta = await _context.Cuentas.Include(c => c.Cliente).ThenInclude(cl => cl.Persona)
+                        .FirstOrDefaultAsync(c => c.NumeroCuenta == req.NumeroCuenta!.Trim(), ct);
+                    if (cuenta == null) return Result<EstadoCuentaDto>.Failure("No encontrado");
+                    if (!esAdmin)
+                    {
+                        var userId = await _context.Users.AsNoTracking().Where(u => u.Email == identidad || u.UserName == identidad || u.Id.ToString() == identidad)
+                            .Select(u => u.Id).FirstOrDefaultAsync(ct);
+                        if (cuenta.Cliente.AppUserId == null || cuenta.Cliente.AppUserId != userId)
+                            return Result<EstadoCuentaDto>.Failure("Forbidden");
+                    }
+                    cuentaIds.Add(cuenta.Id);
+                    clienteId = cuenta.ClienteId;
+                    clienteNombre = $"{cuenta.Cliente.Persona.Nombres} {cuenta.Cliente.Persona.Apellidos}";
+                    numeroCuenta = cuenta.NumeroCuenta;
+                }
+                else if (req.ClienteId != null)
+                {
+                    var cliente = await _context.Clientes.Include(c => c.Persona).FirstOrDefaultAsync(c => c.Id == req.ClienteId, ct);
+                    if (cliente == null) return Result<EstadoCuentaDto>.Failure("No encontrado");
+                    if (!esAdmin)
+                    {
+                        var userId = await _context.Users.AsNoTracking().Where(u => u.Email == identidad || u.UserName == identidad || u.Id.ToString() == identidad)
+                            .Select(u => u.Id).FirstOrDefaultAsync(ct);
+                        if (cliente.AppUserId == null || cliente.AppUserId != userId)
+                            return Result<EstadoCuentaDto>.Failure("Forbidden");
+                    }
+                    cuentaIds = await _context.Cuentas.AsNoTracking().Where(c => c.ClienteId == cliente.Id).Select(c => c.Id).ToListAsync(ct);
+                    clienteId = cliente.Id;
+                    clienteNombre = $"{cliente.Persona.Nombres} {cliente.Persona.Apellidos}";
+                }
+
+                // Si no hay cuentas, 404
+                if (cuentaIds.Count == 0) return Result<EstadoCuentaDto>.Failure("No encontrado");
+
+                var desde = req.Desde.Date;
+                var hastaExcl = req.Hasta.Date.AddDays(1);
+
+                var movs = await _context.Movimientos.AsNoTracking()
+                    .Include(m => m.Tipo)
+                    .Include(m => m.Cuenta)
+                    .Where(m => cuentaIds.Contains(m.CuentaId) && m.Fecha >= desde && m.Fecha < hastaExcl)
+                    .OrderBy(m => m.Fecha).ThenBy(m => m.Id)
+                    .ToListAsync(ct);
+
+                var dto = new EstadoCuentaDto
+                {
+                    ClienteId = clienteId,
+                    ClienteNombre = clienteNombre,
+                    NumeroCuenta = numeroCuenta,
+                    Desde = req.Desde,
+                    Hasta = req.Hasta
+                };
+
+                // Detalle
+                foreach (var m in movs)
+                {
+                    dto.Movimientos.Add(new EstadoCuentaItemDto
+                    {
+                        Fecha = m.Fecha,
+                        NumeroCuenta = m.Cuenta.NumeroCuenta,
+                        TipoCodigo = m.Tipo.Codigo,
+                        Monto = m.Monto,
+                        SaldoPrevio = m.SaldoPrevio,
+                        SaldoPosterior = m.SaldoPosterior,
+                        Descripcion = m.Descripcion
+                    });
+                }
+
+                // Totales y saldos
+                dto.TotalCreditos = movs.Where(x => x.Tipo.Codigo == "CRE").Sum(x => x.Monto);
+                dto.TotalDebitos = movs.Where(x => x.Tipo.Codigo == "DEB").Sum(x => x.Monto);
+
+                if (movs.Count > 0)
+                {
+                    // Si hay varias cuentas, el saldo inicial suma el primer movimiento por cuenta
+                    var primerosPorCuenta = movs.GroupBy(x => x.CuentaId).Select(g => g.First()).ToList();
+                    var ultimosPorCuenta = movs.GroupBy(x => x.CuentaId).Select(g => g.Last()).ToList();
+                    dto.SaldoInicial = primerosPorCuenta.Sum(x => x.SaldoPrevio);
+                    dto.SaldoFinal = ultimosPorCuenta.Sum(x => x.SaldoPosterior);
+                }
+                else
+                {
+                    // Sin movimientos: usar saldos actuales como inicial/final para referencia
+                    var cuentas = await _context.Cuentas.AsNoTracking().Where(c => cuentaIds.Contains(c.Id)).ToListAsync(ct);
+                    dto.SaldoInicial = cuentas.Sum(c => c.SaldoActual);
+                    dto.SaldoFinal = dto.SaldoInicial;
+                }
+
+                return Result<EstadoCuentaDto>.Success(dto);
+            }
+        }
+    }
+}
+
+

--- a/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaRequest.cs
+++ b/bancalite-backend/src/Bancalite.Application/Reportes/EstadoCuenta/EstadoCuentaRequest.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Bancalite.Application.Reportes.EstadoCuenta
+{
+    /// <summary>
+    /// Filtros del reporte de estado de cuenta.
+    /// </summary>
+    public class EstadoCuentaRequest
+    {
+        /// <summary>
+        /// Identificador del cliente (opcional si se indica número de cuenta).
+        /// </summary>
+        public Guid? ClienteId { get; set; }
+
+        /// <summary>
+        /// Número de cuenta (opcional si se indica cliente).
+        /// </summary>
+        public string? NumeroCuenta { get; set; }
+
+        /// <summary>
+        /// Fecha desde (incluyente, UTC).
+        /// </summary>
+        public DateTime Desde { get; set; }
+
+        /// <summary>
+        /// Fecha hasta (incluyente, UTC).
+        /// </summary>
+        public DateTime Hasta { get; set; }
+    }
+}
+

--- a/bancalite-backend/src/Bancalite.Infraestructure/DependencyInjection.cs
+++ b/bancalite-backend/src/Bancalite.Infraestructure/DependencyInjection.cs
@@ -10,6 +10,8 @@ using Bancalite.Infraestructure.Security;
 using Microsoft.Extensions.Options;
 using Bancalite.Infraestructure.Email;
 using Bancalite.Application.Config;
+using Bancalite.Application.Interface;
+using Bancalite.Infraestructure.Report;
 
 namespace Bancalite.Infraestructure;
 
@@ -66,6 +68,7 @@ public static class DependencyInjection
             .Validate(o => !string.IsNullOrWhiteSpace(o.Host), "Smtp:Host es requerido")
             .Validate(o => !string.IsNullOrWhiteSpace(o.SenderEmail), "Smtp:SenderEmail es requerido");
         services.AddScoped<IEmailSender, SmtpEmailSender>();
+        services.AddScoped<IPdfRenderer, PdfRenderer>();
 
         // Ejecuta migraciones y seed en Development al iniciar la app
         if (env.IsDevelopment())

--- a/bancalite-backend/src/Bancalite.Infraestructure/Report/PdfRenderer.cs
+++ b/bancalite-backend/src/Bancalite.Infraestructure/Report/PdfRenderer.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using Bancalite.Application.Interface;
+using Bancalite.Application.Reportes.EstadoCuenta;
+
+namespace Bancalite.Infraestructure.Report
+{
+    /// <summary>
+    /// Renderizador PDF mínimo (plantilla simple) sin dependencias externas.
+    /// - Cabecera por página
+    /// - Tabla de movimientos paginada
+    /// - Totales
+    /// </summary>
+    public class PdfRenderer : IPdfRenderer
+    {
+        public Task<byte[]> RenderEstadoCuentaAsync(object reporteDto, CancellationToken ct = default)
+        {
+            var dto = (EstadoCuentaDto)reporteDto;
+
+            // Construir líneas de texto (cabecera + detalle + totales)
+            var headerLines = new List<string>
+            {
+                "Reporte Estado de Cuenta",
+                !string.IsNullOrWhiteSpace(dto.ClienteNombre) ? $"Cliente: {dto.ClienteNombre}" : null,
+                !string.IsNullOrWhiteSpace(dto.NumeroCuenta) ? $"Cuenta: {dto.NumeroCuenta}" : null,
+                $"Periodo: {dto.Desde:yyyy-MM-dd} a {dto.Hasta:yyyy-MM-dd}",
+                $"Totales: Créditos {dto.TotalCreditos:N2} | Débitos {dto.TotalDebitos:N2}",
+                $"Saldo Inicial: {dto.SaldoInicial:N2} | Saldo Final: {dto.SaldoFinal:N2}",
+                string.Empty,
+                "Fecha | Cuenta | Tipo | Monto | SaldoPrevio | SaldoPosterior | Desc"
+            }.Where(s => s != null)!.ToList()!;
+
+            var detailLines = dto.Movimientos
+                .Select(m => $"{m.Fecha:yyyy-MM-dd} | {m.NumeroCuenta} | {m.TipoCodigo} | {m.Monto:N2} | {m.SaldoPrevio:N2} | {m.SaldoPosterior:N2} | {m.Descripcion}")
+                .ToList();
+
+            var pages = BuildPages(headerLines, detailLines, linesPerPage: 40);
+
+            // Ensamblar PDF 1.4 con múltiples páginas (xref mínimo)
+            var sbPdf = new StringBuilder();
+            sbPdf.AppendLine("%PDF-1.4");
+
+            var objIndex = 1;
+            var catalogId = objIndex++; // 1
+            var pagesId = objIndex++;   // 2
+
+            // Reservar ids de page y contents
+            var pageIds = new List<int>();
+            var contentIds = new List<int>();
+            foreach (var _ in pages)
+            {
+                pageIds.Add(objIndex++);     // page obj
+                contentIds.Add(objIndex++);  // contents obj
+            }
+            var fontId = objIndex++; // font obj
+
+            // Catalog
+            sbPdf.AppendLine($"{catalogId} 0 obj <</Type /Catalog /Pages {pagesId} 0 R>> endobj");
+            // Pages root
+            var kids = string.Join(" ", pageIds.Select(id => $"{id} 0 R"));
+            sbPdf.AppendLine($"{pagesId} 0 obj <</Type /Pages /Kids [{kids}] /Count {pages.Count}>> endobj");
+
+            // Pages and contents
+            for (int i = 0; i < pages.Count; i++)
+            {
+                var pageObj = pageIds[i];
+                var contObj = contentIds[i];
+                var content = BuildContentStream(pages[i]);
+                var contentBytes = Encoding.ASCII.GetBytes(content);
+                sbPdf.AppendLine($"{pageObj} 0 obj <</Type /Page /Parent {pagesId} 0 R /MediaBox [0 0 612 792] /Resources <</Font <</F1 {fontId} 0 R>>>> /Contents {contObj} 0 R>> endobj");
+                sbPdf.AppendLine($"{contObj} 0 obj <</Length {contentBytes.Length}>> stream");
+                sbPdf.Append(content);
+                sbPdf.AppendLine("\nendstream endobj");
+            }
+
+            // Font (Helvetica)
+            sbPdf.AppendLine($"{fontId} 0 obj <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>> endobj");
+
+            // xref mínimo (no offsets reales), suficiente para la mayoría de viewers en pruebas
+            var final = sbPdf.ToString() + "\nxref\n0 1\n0000000000 65535 f \ntrailer <</Size 1/Root 1 0 R>>\nstartxref\n0\n%%EOF\n";
+            return Task.FromResult(Encoding.ASCII.GetBytes(final));
+        }
+
+        private static string EscapePdf(string s) => s.Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)");
+
+        private static List<List<string>> BuildPages(List<string> headerLines, List<string> detailLines, int linesPerPage)
+        {
+            var pages = new List<List<string>>();
+            var headerCount = headerLines.Count;
+            var detailCapacity = Math.Max(1, linesPerPage - headerCount);
+            for (int i = 0; i < detailLines.Count; i += detailCapacity)
+            {
+                var page = new List<string>();
+                page.AddRange(headerLines);
+                page.AddRange(detailLines.Skip(i).Take(detailCapacity));
+                pages.Add(page);
+            }
+            if (pages.Count == 0)
+            {
+                pages.Add(headerLines);
+            }
+            return pages;
+        }
+
+        private static string BuildContentStream(List<string> lines)
+        {
+            var sb = new StringBuilder();
+            sb.Append("BT /F1 10 Tf 50 760 Td 14 TL\n"); // Begin text, set font, move start, leading
+            foreach (var l in lines)
+            {
+                sb.Append($"({EscapePdf(l)}) Tj\nT*\n"); // Show text, next line
+            }
+            sb.Append("ET"); // End text
+            return sb.ToString();
+        }
+    }
+}

--- a/bancalite-backend/src/Bancalite.WebApi/Controllers/ReportesController.cs
+++ b/bancalite-backend/src/Bancalite.WebApi/Controllers/ReportesController.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Bancalite.Application.Interface;
+using Bancalite.Application.Reportes.EstadoCuenta;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bancalite.WebApi.Controllers
+{
+    /// <summary>
+    /// Controlador de reportes: estado de cuenta (JSON y PDF).
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ReportesController : ControllerBase
+    {
+        private readonly ISender _sender;
+        private readonly IPdfRenderer _pdf;
+        public ReportesController(ISender sender, IPdfRenderer pdf)
+        {
+            _sender = sender;
+            _pdf = pdf;
+        }
+
+        /// <summary>
+        /// Devuelve el reporte de estado de cuenta (JSON).
+        /// </summary>
+        [HttpGet]
+        [Authorize]
+        public async Task<ActionResult<EstadoCuentaDto>> Get([FromQuery] Guid? clienteId, [FromQuery] string? numeroCuenta, [FromQuery] DateTime desde, [FromQuery] DateTime hasta, CancellationToken ct)
+        {
+            var req = new EstadoCuentaRequest { ClienteId = clienteId, NumeroCuenta = numeroCuenta, Desde = desde, Hasta = hasta };
+            var result = await _sender.Send(new EstadoCuentaQuery.EstadoCuentaQueryRequest(req), ct);
+            if (!result.IsSuccess) return Problem(statusCode: StatusCodeFromError(result.Error), title: result.Error);
+            return Ok(result.Datos);
+        }
+
+        /// <summary>
+        /// Devuelve el reporte de estado de cuenta como PDF.
+        /// </summary>
+        [HttpGet("pdf")]
+        [Authorize]
+        public async Task<IActionResult> GetPdf([FromQuery] Guid? clienteId, [FromQuery] string? numeroCuenta, [FromQuery] DateTime desde, [FromQuery] DateTime hasta, CancellationToken ct)
+        {
+            var req = new EstadoCuentaRequest { ClienteId = clienteId, NumeroCuenta = numeroCuenta, Desde = desde, Hasta = hasta };
+            var result = await _sender.Send(new EstadoCuentaQuery.EstadoCuentaQueryRequest(req), ct);
+            if (!result.IsSuccess) return Problem(statusCode: StatusCodeFromError(result.Error), title: result.Error);
+
+            var bytes = await _pdf.RenderEstadoCuentaAsync(result.Datos!, ct);
+            var fileName = $"reporte-estado-cuenta-{DateTime.UtcNow:yyyyMMddHHmmss}.pdf";
+            return File(bytes, "application/pdf", fileName);
+        }
+
+        private static int StatusCodeFromError(string? error)
+        {
+            var e = error ?? string.Empty;
+            if (e.StartsWith("Unauthorized", StringComparison.OrdinalIgnoreCase)) return 401;
+            if (e.StartsWith("Forbidden", StringComparison.OrdinalIgnoreCase)) return 403;
+            if (e.StartsWith("BadRequest", StringComparison.OrdinalIgnoreCase)) return 400;
+            if (e.StartsWith("No encontrado", StringComparison.OrdinalIgnoreCase)) return 404;
+            if (e.StartsWith("Unprocessable", StringComparison.OrdinalIgnoreCase)) return 422;
+            if (e.StartsWith("Conflict", StringComparison.OrdinalIgnoreCase)) return 409;
+            return 400;
+        }
+    }
+}
+


### PR DESCRIPTION


# `HU-Rep-01 | T-E1.1` Feat(reportes): añade endpoint para reporte de estado de cuenta en JSON y PDF

* Se crea el `ReportesController` con endpoints para generar el estado de cuenta por cliente o número de cuenta en un rango de fechas.
* Se implementa `GET /reportes` para la versión JSON y `GET /reportes/pdf` para la descarga del archivo PDF.
* La lógica de negocio en `EstadoCuentaQuery` calcula los saldos inicial/final y los totales de créditos/débitos para el período.
* Se añade un `PdfRenderer` sin dependencias externas para la generación de un PDF básico con paginación.
* Se actualiza README.md.
* Referencias: [US_ID=HU-Rep-01] [Task_ID=T-E1.1]

**Tarea:** #69
