### PR TITLE
 `HU-CUE-01 | T-A1.9` Test(clientes): agrega pruebas unitarias para l…

### DIFF
--- a/bancalite-frontend/src/app/core/services/clientes.service.spec.ts
+++ b/bancalite-frontend/src/app/core/services/clientes.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ClientesService } from './clientes.service';
+import { environment } from '../../../environments/environment';
+
+describe('ClientesService (Jest)', () => {
+  let service: ClientesService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    service = TestBed.inject(ClientesService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('debería mapear búsqueda de nombre a param "nombres"', () => {
+    service.list(1, 10, 'Juan').subscribe();
+    const req = http.expectOne(r => r.url === `${environment.apiBaseUrl}/clientes`);
+    expect(req.request.params.get('nombres')).toBe('Juan');
+    expect(req.request.params.has('numeroDocumento')).toBe(false);
+    req.flush({ isSuccess: true, datos: { pagina: 1, tamano: 10, total: 0, items: [] } });
+  });
+
+  it('debería mapear búsqueda numérica a param "numeroDocumento"', () => {
+    service.list(1, 10, '1002003').subscribe();
+    const req = http.expectOne(r => r.url === `${environment.apiBaseUrl}/clientes`);
+    expect(req.request.params.get('numeroDocumento')).toBe('1002003');
+    expect(req.request.params.has('nombres')).toBe(false);
+    req.flush({ isSuccess: true, datos: { pagina: 1, tamano: 10, total: 0, items: [] } });
+  });
+
+  it('debería incluir estado cuando se envía', () => {
+    service.list(1, 10, '', true).subscribe();
+    const req = http.expectOne(r => r.url === `${environment.apiBaseUrl}/clientes`);
+    expect(req.request.params.get('estado')).toBe('true');
+    req.flush({ isSuccess: true, datos: { pagina: 1, tamano: 10, total: 0, items: [] } });
+  });
+});
+

--- a/bancalite-frontend/src/app/features/clientes/pages/clientes-list-page.component.spec.ts
+++ b/bancalite-frontend/src/app/features/clientes/pages/clientes-list-page.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ClientesListPageComponent } from './clientes-list-page.component';
+import { ClientesService } from '../../../core/services/clientes.service';
+import { CatalogosService } from '../../../core/services/catalogos.service';
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
+
+// Evita que sweetalert2 inyecte CSS en JSDOM durante los tests
+jest.mock('sweetalert2', () => ({ __esModule: true, default: { fire: jest.fn() } }));
+
+describe('ClientesListPageComponent (Jest)', () => {
+  let component: ClientesListPageComponent;
+  let fixture: ComponentFixture<ClientesListPageComponent>;
+  let router: Router;
+
+  // Mock simple del servicio con spies configurables
+  const listSpy = jest.fn().mockReturnValue(of({ pagina: 1, tamano: 10, total: 0, items: [] }));
+  const mockClientes = {
+    list: listSpy
+  } as Partial<ClientesService> as ClientesService;
+
+  const mockCatalogos = {
+    generos: () => of([]),
+    tiposDocumento: () => of([])
+  } as any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ClientesListPageComponent],
+      providers: [
+        { provide: ClientesService, useValue: mockClientes },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } },
+        { provide: CatalogosService, useValue: mockCatalogos }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClientesListPageComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+    // La instancia hace un load() inicial → 1er llamado a list()
+    listSpy.mockClear();
+  });
+
+  it('debería hacer búsqueda por nombre con debounce', fakeAsync(() => {
+    // escribe "Juan" y dispara onSearch
+    component['onSearch']({ target: { value: 'Juan' } } as any);
+    // avanza el tiempo del debounce (250ms)
+    tick(260);
+    // expectativa: se llamó a list con q = 'Juan'
+    expect(listSpy).toHaveBeenCalled();
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[2]).toBe('Juan');
+  }));
+
+  it('debería hacer búsqueda por documento con debounce', fakeAsync(() => {
+    component['onSearch']({ target: { value: '1002003' } } as any);
+    tick(260);
+    expect(listSpy).toHaveBeenCalled();
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[2]).toBe('1002003');
+  }));
+
+  it('debería alternar filtro de clientes activos', () => {
+    // alterna a false y fuerza load()
+    component['toggleSoloActivos']({ target: { checked: false } } as any);
+    // expectativa: list llamado con estado false
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[3]).toBe(false);
+  });
+
+  it('debería navegar a crear y editar', () => {
+    const navSpy = jest.spyOn(router, 'navigateByUrl');
+    component.openNew();
+    expect(navSpy).toHaveBeenCalledWith('/clientes/nuevo');
+
+    // simula click en editar
+    component.openEdit({ clienteId: 'abc' } as any, { preventDefault: () => {} } as any);
+    expect(navSpy).toHaveBeenCalledWith('/clientes/abc/editar');
+  });
+});


### PR DESCRIPTION
# `HU-CUE-01 | T-A1.9` Test(clientes): agrega pruebas unitarias para listado de clientes

* Se añade cobertura de pruebas para el `ClientesService`, validando el mapeo de parámetros de búsqueda (`nombres`, `numeroDocumento`) y el filtro de estado.
* Se implementan pruebas para `ClientesListPageComponent`, verificando la lógica de búsqueda con debounce, el filtro de clientes activos y la navegación.
* Se utiliza `HttpClientTestingModule` para mockear las peticiones HTTP y spies de Jest para los servicios inyectados en el componente.
* Referencias: [US_ID=HU-CUE-01] [Task_ID=T-A1.9]

**Tarea:** #102