### PR TITLE
 `HU-CUE-01 | T-A1.9` Test(cuentas): agrega pruebas unitarias para cr…

### DIFF
--- a/bancalite-frontend/src/app/features/cuentas/pages/cuentas-form-page.component.spec.ts
+++ b/bancalite-frontend/src/app/features/cuentas/pages/cuentas-form-page.component.spec.ts
@@ -1,0 +1,73 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CuentasFormPageComponent } from './cuentas-form-page.component';
+import { CuentasService } from '../../../core/services/cuentas.service';
+import { CatalogosService } from '../../../core/services/catalogos.service';
+import { ClientesService } from '../../../core/services/clientes.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('CuentasFormPageComponent (Jest)', () => {
+  let component: CuentasFormPageComponent;
+  let fixture: ComponentFixture<CuentasFormPageComponent>;
+  let router: Router;
+
+  const createSpy = jest.fn().mockReturnValue(of({ isSuccess: true, datos: {} }));
+  const mockCuentas = {
+    create: createSpy
+  } as Partial<CuentasService> as CuentasService;
+
+  const mockCatalogos = {
+    tiposCuenta: () => of([{ id: 't1', codigo: 'AHO', nombre: 'Ahorros', activo: true }])
+  } as Partial<CatalogosService> as CatalogosService;
+
+  const listClientesSpy = jest.fn().mockReturnValue(
+    of({ pagina: 1, tamano: 5, total: 1, items: [{ clienteId: 'cli1', nombres: 'Juan', apellidos: 'Pérez', numeroDocumento: '1002003001' }] })
+  );
+  const mockClientes = { list: listClientesSpy } as Partial<ClientesService> as ClientesService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      declarations: [CuentasFormPageComponent],
+      providers: [
+        { provide: CuentasService, useValue: mockCuentas },
+        { provide: CatalogosService, useValue: mockCatalogos },
+        { provide: ClientesService, useValue: mockClientes },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: (_: string) => null } } } },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(CuentasFormPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('debería mostrar sugerencias y fijar cliente al seleccionar', fakeAsync(() => {
+    // dispara búsqueda de cliente (sujeta a debounce de 250ms)
+    component.onSearchCliente({ target: { value: 'Juan' } } as any);
+    tick(260);
+    // la lista de sugerencias se llena
+    expect(component['sugerencias'].length).toBeGreaterThan(0);
+    // seleccionar la primera opción
+    const sel = component['sugerencias'][0];
+    component.seleccionarCliente(sel);
+    // el formulario debe contener el clienteId y el texto de clienteNombre
+    expect(component.form.get('clienteId')?.value).toBe('cli1');
+    expect(component.form.get('clienteNombre')?.value).toContain('Juan');
+    // y se limpian las sugerencias
+    expect(component['sugerencias'].length).toBe(0);
+  }));
+
+  it('debería crear cuenta y navegar a /cuentas', () => {
+    // completa datos mínimos
+    component.form.patchValue({ tipoCuentaId: 't1', clienteId: 'cli1', saldoInicial: 200 });
+    const navSpy = jest.spyOn(router, 'navigateByUrl');
+    component.save();
+    expect(createSpy).toHaveBeenCalledWith({ numeroCuenta: '', tipoCuentaId: 't1', clienteId: 'cli1', saldoInicial: 200 });
+    expect(navSpy).toHaveBeenCalledWith('/cuentas');
+  });
+});
+

--- a/bancalite-frontend/src/app/features/cuentas/pages/cuentas-list-page.component.spec.ts
+++ b/bancalite-frontend/src/app/features/cuentas/pages/cuentas-list-page.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { CuentasListPageComponent } from './cuentas-list-page.component';
+import { CuentasService } from '../../../core/services/cuentas.service';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+// Evita inyección de CSS de SweetAlert en JSDOM
+jest.mock('sweetalert2', () => ({ __esModule: true, default: { fire: jest.fn() } }));
+
+describe('CuentasListPageComponent (Jest)', () => {
+  let component: CuentasListPageComponent;
+  let fixture: ComponentFixture<CuentasListPageComponent>;
+
+  const listSpy = jest.fn().mockReturnValue(of({ pagina: 1, tamano: 10, total: 0, items: [] }));
+  const mockCuentas = { list: listSpy } as Partial<CuentasService> as CuentasService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CuentasListPageComponent],
+      providers: [
+        { provide: CuentasService, useValue: mockCuentas },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CuentasListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    listSpy.mockClear();
+  });
+
+  it('debería buscar con debounce por texto', fakeAsync(() => {
+    component['onSearch']({ target: { value: '2210' } } as any);
+    tick(260);
+    expect(listSpy).toHaveBeenCalled();
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[2]).toEqual(expect.objectContaining({ q: '2210' }));
+  }));
+
+  it('debería aplicar filtro de cuentas activas', () => {
+    component['toggleActivo']({ target: { checked: false } } as any);
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[2]).toEqual(expect.objectContaining({ activo: false }));
+  });
+
+  it('debería aplicar filtro de clientes activos', () => {
+    component['toggleClientesActivos']({ target: { checked: false } } as any);
+    const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+    expect(last[2]).toEqual(expect.objectContaining({ clientesActivos: false }));
+  });
+});
+


### PR DESCRIPTION
# `HU-CUE-01 | T-A1.9` Test(cuentas): agrega pruebas unitarias para creación y listado de cuentas

* Se implementan pruebas para `CuentasFormPageComponent`, cubriendo la búsqueda de clientes con debounce, la selección de sugerencias y el guardado del formulario.
* Se añade cobertura para `CuentasListPageComponent`, validando la búsqueda por texto y la correcta aplicación de los filtros de estado (cuentas y clientes activos).
* Se utilizan mocks y spies de Jest para simular las respuestas de los servicios `CuentasService`, `ClientesService` y `CatalogosService`.
* Referencias: [US_ID=HU-CUE-01] [Task_ID=T-A1.9]

**Tarea:** #104
